### PR TITLE
Add local database command for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ yarn-error.log*
 .pnp.js
 
 .vscode/*
+.idea/*
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md - GitOps Practice Project
+
+## Commands
+- Backend dev: `cd backend && npm run dev` or `make dev`
+- Docker dev: `make docker-dev` or `cd backend && docker-compose up`
+- Build: `make build` or `cd backend && npm run build`
+- Lint: `cd backend && npm run lint`
+- Format: `cd backend && npm run format`
+- Test: `make test` or `cd backend && npm test`
+- Single test: `cd backend && npx jest path/to/test.ts`
+- Database: `make db-setup` (migrate) or `cd backend && npm run prisma:studio` (UI)
+- Local DB only: `make db-local` or `cd backend && docker-compose up postgres -d`
+
+## Code Style
+- **Imports**: Group imports: external libs first, then internal modules
+- **Formatting**: Use Prettier with 2-space indentation
+- **Types**: Strong typing with TypeScript; avoid `any`
+- **Naming**: camelCase for variables/functions; PascalCase for classes/interfaces
+- **Error Handling**: Use AppError class for custom errors
+- **Architecture**: Follow MVC pattern with controllers/routes/middlewares
+- **Async**: Always use try/catch with async/await
+- **API Design**: RESTful endpoints with proper HTTP methods and status codes
+- **Branching**: Use trunk-based development with short-lived feature branches

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ db-reset:
 	@echo "Resetting database..."
 	@cd backend && npx prisma migrate reset --force
 
+db-local:
+	@echo "Starting local Postgres database..."
+	@cd backend && docker-compose up postgres -d
+
 # Clean
 clean:
 	@echo "Cleaning build artifacts..."
@@ -79,4 +83,5 @@ help:
 	@echo "  make test-frontend    - Run frontend tests"
 	@echo "  make db-setup         - Set up the database with migrations"
 	@echo "  make db-reset         - Reset the database (caution: deletes all data)"
+	@echo "  make db-local         - Start only the local Postgres database in Docker"
 	@echo "  make clean            - Remove build artifacts and node_modules"


### PR DESCRIPTION
## Summary
- Added `make db-local` command to run just the Postgres container for local development
- Updated Makefile with the new command and updated help documentation
- Updated CLAUDE.md to include the new command option

## Test plan
- Run `make db-local` and verify that only the Postgres container starts
- Verify the database is accessible at localhost:5432 with provided credentials

🤖 Generated with [Claude Code](https://claude.ai/code)